### PR TITLE
feat: Add net7 support, removed net5 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.3.0
+- Removed net5 support and added net7 support
+
 # 1.2.0
 - Added overload of `[PhpProperty()]` that accepts integer / long keys. See [#32](https://github.com/StringEpsilon/PhpSerializerNET/issues/32)
 - Allow deserialization of Objects with integer keys

--- a/PhpSerializerNET.Test/PhpSerializerNET.Test.csproj
+++ b/PhpSerializerNET.Test/PhpSerializerNET.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>
 	<ItemGroup>

--- a/PhpSerializerNET/PhpSerializerNET.csproj
+++ b/PhpSerializerNET/PhpSerializerNET.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<Title>PhpSerializerNET</Title>
-		<TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+		<TargetFrameworks>net6.0;net7.0</TargetFrameworks>
 		<Version>1.2.0</Version>
 		<Authors>StringEpsilon</Authors>
 		<Summary>A library for working with the PHP serialization format.</Summary>


### PR DESCRIPTION
Added support for net7.
Removed support for net5 since it is out of support, see: https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core

