### PR TITLE
Fix reference numbering for null values and value references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.1.2 (future)
+
+## Bugfixes
+- Fixed reference numbering for `null` values: In PHP serialization, `null` values (`N;`) are counted in reference numbering, but the library was not incrementing the reference counter for them. This caused incorrect reference resolution when `null` values appeared before referenced objects.
+- Fixed reference numbering for value references: In PHP, value references (`r:`) are counted towards reference numbering, while variable references (`R:`) are not. The library was treating both types the same way (not counting either), which caused reference resolution failures when multiple value references appeared before a later reference target.
+
 # 2.1.1 (2025-03-12)
 
 ## Bugfixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # 2.1.2 (future)
 
 ## Bugfixes
-- Fixed reference numbering for `null` values: In PHP serialization, `null` values (`N;`) are counted in reference numbering, but the library was not incrementing the reference counter for them. This caused incorrect reference resolution when `null` values appeared before referenced objects.
-- Fixed reference numbering for value references: In PHP, value references (`r:`) are counted towards reference numbering, while variable references (`R:`) are not. The library was treating both types the same way (not counting either), which caused reference resolution failures when multiple value references appeared before a later reference target.
+- Fixed `null`  values cause improper de-referencing  when they occur before a reference.
+- Fixed a similar issue caused by the handling of *value* references (as opposed to *variable* references).
 
 # 2.1.1 (2025-03-12)
 

--- a/PhpSerializerNET.Test/DataTypes/MultiRef.cs
+++ b/PhpSerializerNET.Test/DataTypes/MultiRef.cs
@@ -1,0 +1,19 @@
+/**
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+**/
+
+namespace PhpSerializerNET.Test.DataTypes;
+
+public class MultiRef {
+	public MultiRefObj first { get; set; }
+	public MultiRefObj second { get; set; }
+	public MultiRefObj third { get; set; }
+	public MultiRefObj fourth { get; set; }
+	public MultiRefObj fifth { get; set; }
+}
+
+public class MultiRefObj {
+	public string id { get; set; }
+}

--- a/PhpSerializerNET.Test/DataTypes/ReferenceWithNulls.cs
+++ b/PhpSerializerNET.Test/DataTypes/ReferenceWithNulls.cs
@@ -1,0 +1,21 @@
+/**
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+**/
+
+namespace PhpSerializerNET.Test.DataTypes;
+
+public class ReferenceWithNulls {
+	public ReferenceWithNullsItem first { get; set; }
+	public ReferenceWithNullsItem second { get; set; }
+}
+
+public class ReferenceWithNullsItem {
+	public object modifiers { get; set; }
+	public ReferenceWithNullsInner inner { get; set; }
+}
+
+public class ReferenceWithNullsInner {
+	public string value { get; set; }
+}

--- a/PhpSerializerNET.Test/Deserialize/ReferenceDeserializationTest.cs
+++ b/PhpSerializerNET.Test/Deserialize/ReferenceDeserializationTest.cs
@@ -55,4 +55,28 @@ public class ReferenceDeserializationTest {
 		Assert.Equal("two", value.Second.bar);
 	}
 
+	[Fact]
+	public void ReferenceWithNullValuesBefore() {
+		var value = PhpSerialization.Deserialize<ReferenceWithNulls>(
+			"""a:2:{s:5:"first";a:2:{s:9:"modifiers";N;s:5:"inner";O:5:"Inner":1:{s:5:"value";s:4:"test";}}s:6:"second";a:2:{s:9:"modifiers";N;s:5:"inner";r:4;}}"""
+		);
+
+		Assert.Null(value.first.modifiers);
+		Assert.Null(value.second.modifiers);
+		Assert.Equal("test", value.first.inner.value);
+		Assert.Equal("test", value.second.inner.value);
+	}
+
+	[Fact]
+	public void MultipleValueReferencesBeforeTarget() {
+		var value = PhpSerialization.Deserialize<MultiRef>(
+			"""a:5:{s:5:"first";O:3:"Obj":1:{s:2:"id";s:1:"A";}s:6:"second";r:2;s:5:"third";r:2;s:6:"fourth";O:3:"Obj":1:{s:2:"id";s:1:"B";}s:5:"fifth";r:6;}"""
+		);
+
+		Assert.Equal("A", value.first.id);
+		Assert.Equal("A", value.second.id);
+		Assert.Equal("A", value.third.id);
+		Assert.Equal("B", value.fourth.id);
+		Assert.Equal("B", value.fifth.id);
+	}
 }

--- a/PhpSerializerNET.Test/Deserialize/Validation/TestArrayValidation.cs
+++ b/PhpSerializerNET.Test/Deserialize/Validation/TestArrayValidation.cs
@@ -29,7 +29,7 @@ public class TestArrayValidation {
 		if (result is List<object>) {
 			Assert.Equal(24, ((List<object>)result).Count);
 		} else {
-			Assert.True(false, "Expected List<object> but got " + result.GetType().Name);
+			Assert.Fail("Expected List<object> but got " + result.GetType().Name);
 		}
 	}
 }

--- a/PhpSerializerNET/Deserialization/PhpTokenizer.cs
+++ b/PhpSerializerNET/Deserialization/PhpTokenizer.cs
@@ -45,8 +45,10 @@ public ref struct PhpTokenizer {
 	private void GetToken(bool countReference) {
 		switch (this._input[this._position++]) {
 			case (byte)'r':
+				this.GetValueReferenceToken(countReference);
+				break;
 			case (byte)'R':
-				this.GetReferenceToken();
+				this.GetVariableReferenceToken();
 				break;
 			case (byte)'b':
 				this.GetBooleanToken(countReference);
@@ -56,7 +58,7 @@ public ref struct PhpTokenizer {
 					PhpDataType.Null,
 					this._position - 1,
 					ValueSpan.Empty,
-					0
+					countReference ? ++this._reference : 0
 				);
 				this._position++;
 				break;
@@ -114,11 +116,24 @@ public ref struct PhpTokenizer {
 		this._position++;
 	}
 
-	private void GetReferenceToken() {
+	private void GetVariableReferenceToken() {
 		this._position++;
 		int index = this.GetNumbers().GetInt(this._input);
 		if (index <= 0 || index > this._reference) {
 			throw new DeserializationException($"Invalid reference: '{index}' can not be resolved.");
+		}
+		this._tokens[this._tokenPosition++] = new PhpToken(PhpDataType.Reference, this._position, ValueSpan.Empty, index);
+		this._position++;
+	}
+
+	private void GetValueReferenceToken(bool reference) {
+		this._position++;
+		int index = this.GetNumbers().GetInt(this._input);
+		if (index <= 0 || index > this._reference) {
+			throw new DeserializationException($"Invalid reference: '{index}' can not be resolved.");
+		}
+		if (reference) {
+			this._reference++;
 		}
 		this._tokens[this._tokenPosition++] = new PhpToken(PhpDataType.Reference, this._position, ValueSpan.Empty, index);
 		this._position++;

--- a/PhpSerializerNET/Deserialization/PhpTokenizer.cs
+++ b/PhpSerializerNET/Deserialization/PhpTokenizer.cs
@@ -100,7 +100,9 @@ public ref struct PhpTokenizer {
 			PhpDataType.String,
 			position,
 			new ValueSpan(this._position, length),
-			reference ? ++this._reference : 0
+			reference
+				? ++this._reference
+				: 0
 		);
 		this._position += 2 + length;
 	}
@@ -111,7 +113,9 @@ public ref struct PhpTokenizer {
 			PhpDataType.Integer,
 			this._position - 2,
 			this.GetNumbers(),
-			reference ? ++this._reference : 0
+			reference
+				? ++this._reference
+				: 0
 		);
 		this._position++;
 	}

--- a/PhpSerializerNET/PhpSerializerNET.csproj
+++ b/PhpSerializerNET/PhpSerializerNET.csproj
@@ -3,7 +3,7 @@
 		<Title>PhpSerializerNET</Title>
 		<TargetFrameworks>net8.0;net9.0</TargetFrameworks>
 		<LangVersion>12.0</LangVersion>
-		<Version>2.1.1</Version>
+		<Version>2.1.2</Version>
 		<Authors>StringEpsilon</Authors>
 		<Summary>A library for working with the PHP serialization format.</Summary>
 		<PackageTags>php-serialization, php-serializer, php-deserializer</PackageTags>


### PR DESCRIPTION
# Summary
This PR fixes two bugs in reference handling during deserialization that caused incorrect reference resolution in complex serialized structures.

# Problem
When deserializing PHP serialized strings containing references, the library would fail with errors like:
```
PhpSerializer exception
      PhpSerializerNET.DeserializationException: Exception encountered while trying to assign '255' to OrderLocalData.items. See inner exception for details.
       ---> PhpSerializerNET.DeserializationException: Exception encountered while trying to assign '255' to OrderItemLocalModel.comboInformation. See inner exception for details.
       ---> PhpSerializerNET.DeserializationException: Exception encountered while trying to assign '255' to ComboInformationLocalModel.comboId. See inner exception for details.
       ---> PhpSerializerNET.DeserializationException: Can not assign value "255" (at position 2935) to target type of LazyUuidFromString.
```
or
```
PhpSerializer exception
      PhpSerializerNET.DeserializationException: Exception encountered while trying to assign '11111111-1111-1111-1111-111111111111' to OrderLocalData.discountsInfo. See inner exception for details.
       ---> PhpSerializerNET.DeserializationException: Exception encountered while trying to assign '11111111-1111-1111-1111-111111111111' to DiscountsInfoLocalModel.discounts. See inner exception for details.
       ---> PhpSerializerNET.DeserializationException: Exception encountered while trying to assign '11111111-1111-1111-1111-111111111111' to DiscountLocalModel.selectivePositions. See inner exception for details.
       ---> PhpSerializerNET.DeserializationException: Can not assign value "11111111-1111-1111-1111-111111111111" (at position 404) to target type of LazyUuidFromString.
```

This happened because the reference numbering in the library did not match PHP's actual numbering scheme.

# Root Causes
1. Null values not counted in reference numbering
PHP's serialize() counts ALL values in reference numbering, including null. The library was always assigning reference index 0 to null tokens instead of incrementing the counter.
2. Value references (r:) not counted in reference numbering
PHP has two types of references:
- r: — value reference (object/value copy reference)
- R: — variable reference (PHP &$var style reference)
In PHP's serialization, value references are counted towards reference numbering, but variable references are not. The library was treating both the same way (not counting either).

# Example
Given input with multiple value references like r:12 appearing several times before r:49, the library would resolve r:49 to the wrong token because each r:12 should have shifted the numbering by 1.

# Changes
- PhpTokenizer.cs: Modified null token creation to respect the countReference parameter
- PhpTokenizer.cs: Split handling of r: and R: tokens — value references now increment the reference counter, variable references do not
- ReferenceDeserializationTest.cs: Added two new tests specifically for this cases

# Testing
- All existing tests pass
- Added 2 new tests specifically for these cases
- Verified with real-world PHP serialized data containing multiple value references and null values